### PR TITLE
Battlecry targeting

### DIFF
--- a/Assets/Data/Card/Cards/TargetBattlecry.asset
+++ b/Assets/Data/Card/Cards/TargetBattlecry.asset
@@ -41,12 +41,12 @@ MonoBehaviour:
     element: {fileID: 11400000, guid: c59aeb2b5403a3b438f62c2ecfab21c3, type: 2}
     tag: {fileID: 0}
   - stringValue: 
-    intValue: 3
+    intValue: 2
     sprite: {fileID: 0}
     element: {fileID: 11400000, guid: 76ea5fe75a670a7408d6b4f4e8eb3d0a, type: 2}
     tag: {fileID: 0}
   - stringValue: 
-    intValue: 3
+    intValue: 2
     sprite: {fileID: 0}
     element: {fileID: 11400000, guid: 442e234713960d24eade379fe9687174, type: 2}
     tag: {fileID: 0}

--- a/Assets/Data/Card/Cards/TargetBattlecry.asset
+++ b/Assets/Data/Card/Cards/TargetBattlecry.asset
@@ -1,0 +1,72 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a266d4d3fa4641b40bec3145eb7d591b, type: 3}
+  m_Name: TargetBattlecry
+  m_EditorClassIdentifier: 
+  cardType: {fileID: 11400000, guid: f186fb745d82b5b43b86d06fe0742513, type: 2}
+  cost: 2
+  attack: 2
+  health: 2
+  spellId: 0
+  spellValue: 1
+  hasTargeting: 1
+  properties:
+  - stringValue: Battlecry Target
+    intValue: 0
+    sprite: {fileID: 0}
+    element: {fileID: 11400000, guid: e02a0e46268285345955e5aef7d8e680, type: 2}
+    tag: {fileID: 0}
+  - stringValue: <b>Battlecry:</b> Deal 1 damage to the target.
+    intValue: 0
+    sprite: {fileID: 0}
+    element: {fileID: 11400000, guid: 014c9aa08e9234b4dbcbba69a07e0c3e, type: 2}
+    tag: {fileID: 0}
+  - stringValue: 
+    intValue: 0
+    sprite: {fileID: 21300000, guid: 2d0a89872e0fa03498a249b2e8867b13, type: 3}
+    element: {fileID: 11400000, guid: a34d3622c143e694dbd00db03153b7d3, type: 2}
+    tag: {fileID: 0}
+  - stringValue: 
+    intValue: 2
+    sprite: {fileID: 0}
+    element: {fileID: 11400000, guid: c59aeb2b5403a3b438f62c2ecfab21c3, type: 2}
+    tag: {fileID: 0}
+  - stringValue: 
+    intValue: 3
+    sprite: {fileID: 0}
+    element: {fileID: 11400000, guid: 76ea5fe75a670a7408d6b4f4e8eb3d0a, type: 2}
+    tag: {fileID: 0}
+  - stringValue: 
+    intValue: 3
+    sprite: {fileID: 0}
+    element: {fileID: 11400000, guid: 442e234713960d24eade379fe9687174, type: 2}
+    tag: {fileID: 0}
+  - stringValue: Mech
+    intValue: 0
+    sprite: {fileID: 0}
+    element: {fileID: 11400000, guid: 1b55a75e9e6ef5443b73c8c1b7f100de, type: 2}
+    tag: {fileID: 0}
+  - stringValue: 
+    intValue: 0
+    sprite: {fileID: 21300000, guid: c7cb729a20d725540b4fc112990d1d08, type: 3}
+    element: {fileID: 11400000, guid: d08ee459c81df89409e8121c08dcaab9, type: 2}
+    tag: {fileID: 0}
+  - stringValue: 
+    intValue: 0
+    sprite: {fileID: 21300000, guid: 20c486c0ea829cb4590356b24a84becd, type: 3}
+    element: {fileID: 11400000, guid: 2a221db5eef0b5d4aa274edccdb4aa02, type: 2}
+    tag: {fileID: 0}
+  - stringValue: 
+    intValue: 0
+    sprite: {fileID: 0}
+    element: {fileID: 0}
+    tag: {fileID: 11400000, guid: 94d5fb4cbcea6ad449b2f01d4b84ad02, type: 2}

--- a/Assets/Data/Card/Cards/TargetBattlecry.asset.meta
+++ b/Assets/Data/Card/Cards/TargetBattlecry.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 247bf2c54a235fd4d9e88cf586cbf00b
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Data/Players/Player_1.asset
+++ b/Assets/Data/Players/Player_1.asset
@@ -38,12 +38,12 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 237b4392d95df7a49b6eb5ed5351fb4b, type: 2}
   - {fileID: 11400000, guid: a7e848da399dd474ab6079a73944c7c1, type: 2}
   - {fileID: 11400000, guid: a7e848da399dd474ab6079a73944c7c1, type: 2}
-  - {fileID: 11400000, guid: f26bb74bee2d07248aa66bfe169e9a46, type: 2}
-  - {fileID: 11400000, guid: f26bb74bee2d07248aa66bfe169e9a46, type: 2}
-  - {fileID: 11400000, guid: f26bb74bee2d07248aa66bfe169e9a46, type: 2}
-  - {fileID: 11400000, guid: f26bb74bee2d07248aa66bfe169e9a46, type: 2}
-  - {fileID: 11400000, guid: f26bb74bee2d07248aa66bfe169e9a46, type: 2}
-  - {fileID: 11400000, guid: f26bb74bee2d07248aa66bfe169e9a46, type: 2}
+  - {fileID: 11400000, guid: 247bf2c54a235fd4d9e88cf586cbf00b, type: 2}
+  - {fileID: 11400000, guid: 247bf2c54a235fd4d9e88cf586cbf00b, type: 2}
+  - {fileID: 11400000, guid: 247bf2c54a235fd4d9e88cf586cbf00b, type: 2}
+  - {fileID: 11400000, guid: 247bf2c54a235fd4d9e88cf586cbf00b, type: 2}
+  - {fileID: 11400000, guid: 247bf2c54a235fd4d9e88cf586cbf00b, type: 2}
+  - {fileID: 11400000, guid: 247bf2c54a235fd4d9e88cf586cbf00b, type: 2}
   - {fileID: 11400000, guid: f26bb74bee2d07248aa66bfe169e9a46, type: 2}
   - {fileID: 11400000, guid: f26bb74bee2d07248aa66bfe169e9a46, type: 2}
   isHumanPlayer: 1

--- a/Assets/Data/Players/Player_2.asset
+++ b/Assets/Data/Players/Player_2.asset
@@ -40,10 +40,10 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 237b4392d95df7a49b6eb5ed5351fb4b, type: 2}
   - {fileID: 11400000, guid: a7e848da399dd474ab6079a73944c7c1, type: 2}
   - {fileID: 11400000, guid: a7e848da399dd474ab6079a73944c7c1, type: 2}
-  - {fileID: 11400000, guid: f26bb74bee2d07248aa66bfe169e9a46, type: 2}
-  - {fileID: 11400000, guid: f26bb74bee2d07248aa66bfe169e9a46, type: 2}
-  - {fileID: 11400000, guid: f26bb74bee2d07248aa66bfe169e9a46, type: 2}
-  - {fileID: 11400000, guid: f26bb74bee2d07248aa66bfe169e9a46, type: 2}
+  - {fileID: 11400000, guid: 247bf2c54a235fd4d9e88cf586cbf00b, type: 2}
+  - {fileID: 11400000, guid: 247bf2c54a235fd4d9e88cf586cbf00b, type: 2}
+  - {fileID: 11400000, guid: 247bf2c54a235fd4d9e88cf586cbf00b, type: 2}
+  - {fileID: 11400000, guid: 247bf2c54a235fd4d9e88cf586cbf00b, type: 2}
   - {fileID: 11400000, guid: f26bb74bee2d07248aa66bfe169e9a46, type: 2}
   - {fileID: 11400000, guid: f26bb74bee2d07248aa66bfe169e9a46, type: 2}
   isHumanPlayer: 0

--- a/Assets/Data/Resources/ResourcesManager.asset
+++ b/Assets/Data/Resources/ResourcesManager.asset
@@ -27,3 +27,4 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 260821701d9941c4d99d4403a35aa178, type: 2}
   - {fileID: 11400000, guid: c80bde7df5d35f64c988674acd210e10, type: 2}
   - {fileID: 11400000, guid: f26bb74bee2d07248aa66bfe169e9a46, type: 2}
+  - {fileID: 11400000, guid: 247bf2c54a235fd4d9e88cf586cbf00b, type: 2}

--- a/Assets/Scripts/GameElements/PlayerBoardLogic.cs
+++ b/Assets/Scripts/GameElements/PlayerBoardLogic.cs
@@ -36,18 +36,10 @@ namespace ZCCG
                     Debug.Log("This is the current player holder when dropping" + p.username );
                     inst.currentLogic = cardDownLogic;
                     inst.gameObject.SetActive(true); 
-                    Debug.Log(inst.isBattlecry);
 
-                    if (inst.isBattlecry)
+                    if (inst.isBattlecry && !c.hasTargeting)
                     {
-                        if (c.hasTargeting)
-                        {
-                            Debug.Log("Setting battlecry target");
-                            Settings.gameManager.SetState(targetSelection);
-                            onTargetSelection.Raise();
-                            return;
-                        }
-                        else
+                        if (!c.hasTargeting)
                         {
                             Settings.spellManager.CastSpell(inst.spellId, inst.spellValue, null, null);
                         }
@@ -74,8 +66,15 @@ namespace ZCCG
                     inst.currentLogic = cardDownLogic;
                     Settings.gameManager.currentPlayer.AddHeroAttack(inst.currentAttack);
                     Settings.gameManager.currentPlayer.heroStatsUI.UpdateAttack();
-            
                     inst.gameObject.SetActive(true);
+
+                    if (inst.isBattlecry && !c.hasTargeting)
+                    {
+                        if (!c.hasTargeting)
+                        {
+                            Settings.spellManager.CastSpell(inst.spellId, inst.spellValue, null, null);
+                        }
+                    }
                 }
                 else
                 if(c.cardType is Spell)

--- a/Assets/Scripts/GameElements/PlayerBoardLogic.cs
+++ b/Assets/Scripts/GameElements/PlayerBoardLogic.cs
@@ -72,6 +72,7 @@ namespace ZCCG
                     {
                         if (!c.hasTargeting)
                         {
+                            Settings.spellManager.spellQueued = true;
                             Settings.spellManager.CastSpell(inst.spellId, inst.spellValue, null, null);
                         }
                     }

--- a/Assets/Scripts/Managers/SpellManager.cs
+++ b/Assets/Scripts/Managers/SpellManager.cs
@@ -36,8 +36,8 @@ namespace ZCCG
             // gets the "damage" value from the spell 
             //damage = Settings.gameManager.currentSelectedHolder.currentSelectedCard.currentAttack;
             Debug.Log("Spell Was Cast");
-            //if (spellQueued == true)
-            //{
+            if (spellQueued == true)
+            {
                 switch (spellId)
                 {
                     //deal X spell damage to single target  
@@ -124,6 +124,7 @@ namespace ZCCG
                         Debug.Log("Spell does not exist");
                         return;
                 }
+            }
         }
 
         // public void SetSpellTarget()

--- a/Assets/Scripts/Turns/EndOfTurnPhase.cs
+++ b/Assets/Scripts/Turns/EndOfTurnPhase.cs
@@ -46,6 +46,7 @@ namespace ZCCG
                     Debug.Log("This card has the EOT tag, Do its stuff!");
                     if (!inst.isSilenced)
                     {
+                        Settings.spellManager.spellQueued = true;
                         Settings.spellManager.CastSpell(inst.spellId, inst.spellValue, null, Settings.gameManager.currentPlayer);
                     }
                     

--- a/Assets/Scripts/Turns/StartOfTurnPhase.cs
+++ b/Assets/Scripts/Turns/StartOfTurnPhase.cs
@@ -49,6 +49,7 @@ namespace ZCCG
                     Debug.Log("This card has the SOT tag!");
                     if (!inst.isSilenced)
                     {
+                        Settings.spellManager.spellQueued = true;
                         Settings.spellManager.CastSpell(inst.spellId, inst.spellValue, null, Settings.gameManager.currentPlayer);
                     }
 

--- a/Assets/Scripts/_Actions/MouseHoldWithCard.cs
+++ b/Assets/Scripts/_Actions/MouseHoldWithCard.cs
@@ -51,7 +51,13 @@ namespace ZCCG.GameStates
                     {
                         inst.gameObject.SetActive(false);
                     }
-                    
+
+                    // Makes sure to queue the "spell" for a one time use.
+                    if (c.cardType is Minion || c.cardType is Weapon)
+                    {
+                        Settings.spellManager.spellQueued= true;
+                    }
+
                     Settings.gameManager.SetState(targetSelectionState);
                     Debug.Log("Setstate: spellTargetSelection");
                     p.handcards.Remove(inst);

--- a/Assets/Scripts/_Actions/MouseHoldWithCard.cs
+++ b/Assets/Scripts/_Actions/MouseHoldWithCard.cs
@@ -42,12 +42,16 @@ namespace ZCCG.GameStates
                     }
                 }
                 
-                // will use this for spells only. Battlecries targeting will happen after drop
+                // will use this for spells & Battlecries
                 // bypass normal drop case and go straight to targeting, checking for mana requirement first
-                if (inst.viz.card.hasTargeting && canUse && c.cardType is Spell)
+                if (inst.viz.card.hasTargeting && canUse)
                 {
                     Debug.Log("Setting spell target");
-                    inst.gameObject.SetActive(false);
+                    if (c.cardType is Spell)
+                    {
+                        inst.gameObject.SetActive(false);
+                    }
+                    
                     Settings.gameManager.SetState(targetSelectionState);
                     Debug.Log("Setstate: spellTargetSelection");
                     p.handcards.Remove(inst);

--- a/Assets/Scripts/_Actions/SelectTarget_Attack.cs
+++ b/Assets/Scripts/_Actions/SelectTarget_Attack.cs
@@ -38,6 +38,9 @@ namespace ZCCG
         {
             Debug.Log("got here - Attack targeting State");
 
+            PlayerHolder op = Settings.gameManager.otherPlayer;
+            PlayerHolder cp = Settings.gameManager.currentPlayer;
+
             isHero = false;
             isMinion = false;
             isSpell = false;
@@ -46,27 +49,34 @@ namespace ZCCG
             currentHolder = Settings.gameManager.currentSelectedHolder;
             Settings.gameManager.dropArea.SetActive(false);
 
+            // hides the held card overlay (for battlecries and spells)
+            if (currentHolder.heldCardVariantOverlay.gameObject != null)
+            {
+                currentHolder.heldCardVariantOverlay.gameObject.SetActive(false);
+            }
+
             if(currentHolder.GetSelectedCard() != null)
             {
-                Debug.Log("Try succeeded for card");
                 currentCard = currentHolder.GetSelectedCard();
                 currentType = currentCard.viz.card.cardType;
                 
-
                 if (currentType is Minion)
                 {
+                    Debug.Log("Minion Battlecry Targeting");
                     isMinion = true;
+                    
                     currentSelectedPosition = currentCard.transform.position;
                 }
                 if (currentType is Spell)
                 {
+                    Debug.Log("Spell Targeting");
                     isSpell = true;
                     currentCard.gameObject.SetActive(false);
-                    currentHolder.heldCardVariantOverlay.gameObject.SetActive(false);
                     currentSelectedPosition = Settings.gameManager.currentPlayer.heroStatsUI.transform.position;
                 }
                 if (currentType is Weapon)
                 {
+                    Debug.Log("Weapon Battlecry Targeting");
                     isWeapon = true;
                     currentSelectedPosition = currentCard.transform.position;
                 }
@@ -102,8 +112,6 @@ namespace ZCCG
                 {
 
                     CardInstance inst = r.gameObject.GetComponentInParent<CardInstance>();
-                    PlayerHolder op = Settings.gameManager.otherPlayer;
-                    PlayerHolder cp = Settings.gameManager.currentPlayer;
                     HeroManager hm = r.gameObject.GetComponentInParent<HeroManager>();
 
                     //Taunt Check
@@ -137,7 +145,7 @@ namespace ZCCG
                                 }
                                 if(isMinion)
                                 {
-                                    
+
 
                                     Debug.Log("attacker's atk/health: "+ currentCard.currentAttack +"/"+ currentCard.currentHealth);
                                     Debug.Log("defender's atk/health: " + inst.currentAttack + "/" + inst.currentHealth);
@@ -216,12 +224,31 @@ namespace ZCCG
                     }
 
                     // If no valid target was selected, and it was a spell, add it back to your hand
-                    if (isSpell && hm == null & inst == null) 
+                    if (isSpell && hm == null && inst == null) 
                     {
                         Debug.Log("Adding spell back to hand");
                         currentCard.gameObject.SetActive(true);
                         Settings.gameManager.currentPlayer.handcards.Add(currentCard);
                     }
+
+                    if (isMinion && currentCard.viz.card.hasTargeting && hm == null && inst == null)
+                    {
+                        Debug.Log("Adding Battlecry Minion back to hand");
+                        currentCard.gameObject.SetActive(true);
+                        cp.cardsDown.Remove(currentCard);
+                        Settings.gameManager.currentPlayer.handcards.Add(currentCard);
+                    }
+
+
+                    // TODO:
+                    // Handle weapon drops with 
+                    // if (isWeapon && currentCard.viz.card.hasTargeting && hm == null && inst == null)
+                    // {
+                    //     Debug.Log("Adding Battlecry Weapon back to hand");
+                    //     currentCard.gameObject.SetActive(true);
+                    //     // cp.currentHolder.weaponHolder.value.gameObject. 
+                    //     Settings.gameManager.currentPlayer.handcards.Add(currentCard);
+                    // }
 
                     Settings.gameManager.targetingLine.gameObject.SetActive(false);
                     currentHolder.heldCardVariantOverlay.gameObject.SetActive(true);
@@ -243,8 +270,28 @@ namespace ZCCG
                 {
                     Debug.Log("Adding spell back to hand");
                     currentCard.gameObject.SetActive(true);
-                    Settings.gameManager.currentPlayer.handcards.Add(currentCard);
+                    cp.handcards.Add(currentCard);
                 }
+
+                if (isMinion && currentCard.viz.card.hasTargeting)
+                {
+                    Debug.Log("Adding Battlecry Minion back to hand");
+                    currentCard.gameObject.SetActive(true);
+                    cp.handcards.Add(currentCard);
+                    cp.cardsDown.Remove(currentCard);
+                }
+
+
+                // TODO:
+                // Handle weapon drops with 
+                // if (isWeapon && currentCard.viz.card.hasTargeting)
+                // {
+                //     Debug.Log("Adding Battlecry Weapon back to hand");
+                //     currentCard.gameObject.SetActive(true);
+                //     // cp.currentHolder.weaponHolder.value.gameObject. 
+                //     Settings.gameManager.currentPlayer.handcards.Add(currentCard);
+                // }
+
                 Debug.Log("Right Click, attack aborted");
                 Settings.gameManager.targetingLine.gameObject.SetActive(false);
                 currentHolder.heldCardVariantOverlay.gameObject.SetActive(true);

--- a/Assets/Scripts/_Actions/SelectTarget_Attack.cs
+++ b/Assets/Scripts/_Actions/SelectTarget_Attack.cs
@@ -145,6 +145,7 @@ namespace ZCCG
                                 }
                                 if(isMinion)
                                 {
+                                    // Makes sure to only use spell when it is dropped "battlecry effect"
                                     if (currentCard.viz.card.hasTargeting && Settings.spellManager.spellQueued) // Change this to a battlecry used/unused status on card to check
                                     {
                                         Settings.spellManager.CastSpell(currentCard.spellId, currentCard.spellValue, inst, null);
@@ -192,7 +193,8 @@ namespace ZCCG
                                 }
                                 if (isMinion)
                                 {
-                                    if (currentCard.viz.card.hasTargeting && Settings.spellManager.spellQueued) // Change this to a battlecry used/unused status on card to check
+                                    // Makes sure to only use spell when it is dropped "battlecry effect"
+                                    if (currentCard.viz.card.hasTargeting && Settings.spellManager.spellQueued) 
                                     {
                                         Settings.spellManager.CastSpell(currentCard.spellId, currentCard.spellValue, null, op);
                                     }
@@ -217,8 +219,8 @@ namespace ZCCG
                         if (hm.player.Equals(cp))
                         {
                             Debug.Log(" Your target is your own hero");
-
-                            if (isMinion && currentCard.viz.card.hasTargeting && Settings.spellManager.spellQueued) // Change this to a battlecry used/unused status on card to check
+                            // Makes sure to only use spell when it is dropped "battlecry effect"
+                            if (isMinion && currentCard.viz.card.hasTargeting && Settings.spellManager.spellQueued) 
                             {
                                 Settings.spellManager.CastSpell(currentCard.spellId, currentCard.spellValue, null, cp);
 

--- a/Assets/Scripts/_Actions/SelectTarget_Attack.cs
+++ b/Assets/Scripts/_Actions/SelectTarget_Attack.cs
@@ -145,14 +145,19 @@ namespace ZCCG
                                 }
                                 if(isMinion)
                                 {
-
-
+                                    if (currentCard.viz.card.hasTargeting && Settings.spellManager.spellQueued) // Change this to a battlecry used/unused status on card to check
+                                    {
+                                        Settings.spellManager.CastSpell(currentCard.spellId, currentCard.spellValue, inst, null);
+                                    }
+                                    else
+                                    {
                                     Debug.Log("attacker's atk/health: "+ currentCard.currentAttack +"/"+ currentCard.currentHealth);
                                     Debug.Log("defender's atk/health: " + inst.currentAttack + "/" + inst.currentHealth);
 
                                     inst.SubtractCardHealth(currentCard.currentAttack);
                                     currentCard.SubtractCardHealth(inst.currentAttack);
                                     SetHasAttacked(currentHero, null);
+                                    }
 
                                 }
                                 if(isSpell)
@@ -187,9 +192,16 @@ namespace ZCCG
                                 }
                                 if (isMinion)
                                 {
+                                    if (currentCard.viz.card.hasTargeting && Settings.spellManager.spellQueued) // Change this to a battlecry used/unused status on card to check
+                                    {
+                                        Settings.spellManager.CastSpell(currentCard.spellId, currentCard.spellValue, null, op);
+                                    }
+                                    else
+                                    {
                                     op.SubtractHeroCurrentHealth(currentCard.currentAttack);
                                     SetHasAttacked(currentHero, null);
                                     isMinion = false;
+                                    }
                                 }
                                 if (isSpell)
                                 {
@@ -205,6 +217,13 @@ namespace ZCCG
                         if (hm.player.Equals(cp))
                         {
                             Debug.Log(" Your target is your own hero");
+
+                            if (isMinion && currentCard.viz.card.hasTargeting && Settings.spellManager.spellQueued) // Change this to a battlecry used/unused status on card to check
+                            {
+                                Settings.spellManager.CastSpell(currentCard.spellId, currentCard.spellValue, null, cp);
+
+                            }
+
                             if(isSpell)
                             {
                                 Settings.spellManager.CastSpell(currentCard.spellId, currentCard.spellValue, null, cp);


### PR DESCRIPTION
Battlecry logic has been implemented for minions.
TODO:
- Add battelcries for weapons
- Fix return to hand logic when battelcry isnt used, or selecting the wrong target